### PR TITLE
Rust 1.0.0-beta fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ repository = "https://github.com/dcuddeback/serial-rs.git"
 [dependencies]
 termios = "0.0.5"
 libc = "0.1.5"
+time = "0.1.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-#![feature(std_misc)]
+extern crate time;
 
 use std::io;
 
 use std::default::Default;
-use std::time::duration::Duration;
+use time::Duration;
 
 pub use BaudRate::*;
 pub use CharSize::*;

--- a/src/posix/poll.rs
+++ b/src/posix/poll.rs
@@ -1,10 +1,11 @@
 #![allow(non_camel_case_types,dead_code)]
 
 extern crate libc;
+extern crate time;
 
 use std::io;
 
-use std::time::duration::Duration;
+use time::Duration;
 
 use self::libc::{c_int,c_short};
 

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -1,12 +1,13 @@
 extern crate libc;
 extern crate termios;
+extern crate time;
 
 use std::io;
 
 use std::default::Default;
 use std::ffi::CString;
 use std::path::Path;
-use std::time::duration::Duration;
+use time::Duration;
 
 use std::os::unix::prelude::OsStrExt;
 


### PR DESCRIPTION
Simple fix by using `time` crate as replacement for unstable Duration type to allow compilation for the Rust 1.0.0 beta.

This fix can be removed, when 1.1.0 will (most probably) contain its own stable Duration type.
