### PR TITLE
Serial enumeration for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 rust:
-  - 1.3.0
+  - 1.4.0
   - stable
   - beta
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rust:
   - 1.3.0
   - stable
   - beta
+
+addons:
+  apt:
+    packages:
+    - libudev-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,18 +32,22 @@ ioctl-rs = "0.1.5"
 [target.i686-unknown-linux-gnu.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+libudev = "0.2.0"
 
 [target.mips-unknown-linux-gnu.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+libudev = "0.2.0"
 
 [target.mipsel-unknown-linux-gnu.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+libudev = "0.2.0"
 
 [target.powerpc-unknown-linux-gnu.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+libudev = "0.2.0"
 
 [target.x86_64-apple-darwin.dependencies]
 termios = "0.2.2"
@@ -60,6 +64,7 @@ ioctl-rs = "0.1.5"
 [target.x86_64-unknown-linux-gnu.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+libudev = "0.2.0"
 
 [target.x86_64-unknown-openbsd.dependencies]
 termios = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,15 @@ libudev = "0.2.0"
 [target.x86_64-unknown-openbsd.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+
+[target.i686-pc-windows-msvc.dependencies]
+winreg = "0.3"
+
+[target.x86_64-pc-windows-msvc.dependencies]
+winreg = "0.3"
+
+[target.i686-pc-windows-gnu.dependencies]
+winreg = "0.3"
+
+[target.x86_64-pc-windows-gnu.dependencies]
+winreg = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,3 +885,8 @@ pub struct PortInfo {
 pub fn list_ports() -> Result<Vec<PortInfo>> {
     posix::list_ports()
 }
+
+#[cfg(target_os = "windows")]
+pub fn list_ports() -> Result<Vec<PortInfo>> {
+    windows::list_ports()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,3 +890,8 @@ pub fn list_ports() -> Result<Vec<PortInfo>> {
 pub fn list_ports() -> Result<Vec<PortInfo>> {
     windows::list_ports()
 }
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub fn list_ports() -> Result<Vec<PortInfo>> {
+    Err(Error::new(ErrorKind::Unknown, "list_ports() not implemented for platform"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@ pub enum ErrorKind {
     /// A parameter was incorrect.
     InvalidInput,
 
-    /// An I/O error occured.
+    /// An unknown error occurred.
+    Unknown,
+
+    /// An I/O error occurred.
     ///
     /// The type of I/O error is determined by the inner `io::ErrorKind`.
     Io(io::ErrorKind)
@@ -99,6 +102,7 @@ impl From<Error> for io::Error {
         let kind = match error.kind {
             ErrorKind::NoDevice => io::ErrorKind::NotFound,
             ErrorKind::InvalidInput => io::ErrorKind::InvalidInput,
+            ErrorKind::Unknown => io::ErrorKind::Other,
             ErrorKind::Io(kind) => kind
         };
 
@@ -867,4 +871,17 @@ mod tests {
         settings.set_flow_control(FlowSoftware);
         assert_eq!(settings.flow_control(), Some(FlowSoftware));
     }
+}
+
+
+/// A device-independent implementation of serial port information.
+#[derive(Debug,Clone,PartialEq,Eq)]
+pub struct PortInfo {
+    /// Port name
+    pub port_name: String,
+}
+
+#[cfg(target_os = "linux")]
+pub fn list_ports() -> Result<Vec<PortInfo>> {
+    posix::list_ports()
 }

--- a/src/posix/error.rs
+++ b/src/posix/error.rs
@@ -1,4 +1,6 @@
 extern crate libc;
+#[cfg(target_os = "linux")]
+extern crate libudev;
 
 use std::error::Error;
 use std::ffi::CStr;
@@ -33,6 +35,18 @@ pub fn from_io_error(io_error: io::Error) -> ::Error {
             let description = io_error.description().to_string();
 
             ::Error::new(::ErrorKind::Io(io_error.kind()), description)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl From<libudev::Error> for ::Error {
+    fn from(e: libudev::Error) -> ::Error {
+        let description = e.description().to_string();
+        match e.kind() {
+            libudev::ErrorKind::NoMem => ::Error::new(::ErrorKind::Unknown, description),
+            libudev::ErrorKind::InvalidInput => ::Error::new(::ErrorKind::InvalidInput, description),
+            libudev::ErrorKind::Io(a) => ::Error::new(::ErrorKind::Io(a), description)
         }
     }
 }

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -657,9 +657,14 @@ pub fn list_ports() -> ::Result<Vec<PortInfo>> {
         try!(enumerator.match_subsystem("tty"));
         let devices = try!(enumerator.scan_devices());
         for d in devices {
-            if d.parent().is_some() {
+            if let Some(p) = d.parent() {
                 if let Some(devnode) = d.devnode() {
                     if let Some(path) = devnode.to_str() {
+                        if let Some(driver) = p.driver() {
+                            if driver == "serial8250" && ::open(Path::new(devnode)).is_err() {
+                                continue;
+                            }
+                        }
                         vec.push(PortInfo { port_name: String::from(path) });
                     }
                 }

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -1,4 +1,6 @@
 extern crate libc;
+#[cfg(target_os = "linux")]
+extern crate libudev;
 extern crate termios;
 extern crate ioctl_rs as ioctl;
 
@@ -11,7 +13,7 @@ use std::os::unix::prelude::*;
 
 use self::libc::{c_int,c_void,size_t};
 
-use ::{SerialDevice,SerialPortSettings};
+use ::{SerialDevice,SerialPortSettings,PortInfo};
 
 
 #[cfg(target_os = "linux")]
@@ -645,4 +647,24 @@ mod tests {
         settings.set_flow_control(::FlowNone);
         assert_eq!(settings.flow_control(), Some(::FlowNone));
     }
+}
+
+#[cfg(target_os = "linux")]
+pub fn list_ports() -> ::Result<Vec<PortInfo>> {
+    let mut vec = Vec::new();
+    if let Ok(context) = libudev::Context::new() {
+        let mut enumerator = try!(libudev::Enumerator::new(&context));
+        try!(enumerator.match_subsystem("tty"));
+        let devices = try!(enumerator.scan_devices());
+        for d in devices {
+            if d.parent().is_some() {
+                if let Some(devnode) = d.devnode() {
+                    if let Some(path) = devnode.to_str() {
+                        vec.push(PortInfo { port_name: String::from(path) });
+                    }
+                }
+            }
+        }
+    }
+    Ok(vec)
 }

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -1,4 +1,5 @@
 extern crate libc;
+extern crate winreg;
 
 use std::ffi::OsStr;
 use std::io;
@@ -6,12 +7,16 @@ use std::mem;
 use std::ptr;
 use std::time::Duration;
 
+use self::winreg::RegKey;
+use self::winreg::types::FromRegValue;
+use self::winreg::enums::*;
+
 use std::os::windows::prelude::*;
 
 use self::libc::c_void;
 
 use super::ffi::*;
-use ::{SerialDevice,SerialPortSettings};
+use ::{SerialDevice,SerialPortSettings,PortInfo};
 
 
 /// A serial port implementation for Windows COM ports.
@@ -340,4 +345,18 @@ impl SerialPortSettings for COMSettings {
             }
         }
     }
+}
+
+pub fn list_ports() -> ::Result<Vec<PortInfo>> {
+    let mut vec = Vec::new();
+    let system = try!(RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey_with_flags("HARDWARE\\DEVICEMAP\\SERIALCOMM", KEY_READ));
+    for reg_val in system.enum_values() {
+        if let Ok((_, value)) = reg_val {
+            if let Ok(val_str) = FromRegValue::from_reg_value(&value) {
+                vec.push(PortInfo { port_name: val_str });
+            }
+        }
+    }
+    Ok(vec)
 }


### PR DESCRIPTION
Start of work for #13. This doesn't actually work yet, but I wanted feedback on the API that I'm adding to serial-rs before I go too far down this road. I'm not familiar with Rust enough to know what's "rusty", so I'm basically just copying from the existing API in this lib.

Note that SerialPortInfo will likely change to include more data (see http://code.qt.io/cgit/qt/qtserialport.git/tree/src/serialport/qserialportinfo.h#n62), but for the basic implementation only the port name is required, so I'm planning on leaving it at that for the first implementation.

Biggest bike-shedding issue is what to name `scan_ports()`, Qt uses `AvailablePorts()` (which I like)_ while Python uses `list_ports.comports()` (which I don't). I think `available_ports()` would be good, and I'll change it in the next revision if there's no complaint.
