### PR TITLE
Make `windows::com::COMPort` implement `Send` trait

### DIFF
--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -20,6 +20,8 @@ pub struct COMPort {
     timeout: Duration
 }
 
+unsafe impl Send for COMPort {}
+
 impl COMPort {
     /// Opens a COM port as a serial device.
     ///


### PR DESCRIPTION
Thanks to that it can be used with move semantics in multithreading applications.

This should fix #16.
