### PR TITLE
Provide a `try_clone()` method for `SerialPort` and `SerialDevice`

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -161,7 +161,15 @@ impl SerialDevice for TTYPort {
     type Settings = TTYSettings;
 
     fn try_clone(&self) -> ::Result<TTYPort> {
-        unimplemented!()
+        match unsafe { libc::dup(self.fd) } {
+            -1 => Err(super::error::last_os_error()),
+            dup_fd => {
+                Ok(TTYPort {
+                    fd: dup_fd,
+                    timeout: self.timeout,
+                })
+            },
+        }
     }
 
     fn read_settings(&self) -> ::Result<TTYSettings> {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -160,6 +160,10 @@ impl io::Write for TTYPort {
 impl SerialDevice for TTYPort {
     type Settings = TTYSettings;
 
+    fn try_clone(&self) -> ::Result<TTYPort> {
+        unimplemented!()
+    }
+
     fn read_settings(&self) -> ::Result<TTYSettings> {
         use self::termios::{CREAD,CLOCAL}; // cflags
         use self::termios::{ICANON,ECHO,ECHOE,ECHOK,ECHONL,ISIG,IEXTEN}; // lflags

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -139,7 +139,23 @@ impl SerialDevice for COMPort {
     type Settings = COMSettings;
     
     fn try_clone(&self) -> ::Result<COMPort> {
-        unimplemented!()
+        let mut new_handle: HANDLE = ptr::null_mut() as HANDLE;
+        match unsafe { DuplicateHandle(
+                GetCurrentProcess(),
+	   			self.handle,
+				GetCurrentProcess(),
+				&mut new_handle as *mut HANDLE,
+				0,
+				0,
+				DUPLICATE_SAME_ACCESS) } {
+	    	0 => Err(super::error::last_os_error()),
+	    	_ => {
+	    	    Ok(COMPort {
+	    	        handle: new_handle,
+	    	        timeout: self.timeout,
+	    	    })
+	    	},
+        }
     }
 
     fn read_settings(&self) -> ::Result<COMSettings> {

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -137,6 +137,10 @@ impl io::Write for COMPort {
 
 impl SerialDevice for COMPort {
     type Settings = COMSettings;
+    
+    fn try_clone(&self) -> ::Result<COMPort> {
+        unimplemented!()
+    }
 
     fn read_settings(&self) -> ::Result<COMSettings> {
         let mut dcb = DCB::new();

--- a/src/windows/ffi.rs
+++ b/src/windows/ffi.rs
@@ -19,12 +19,14 @@ pub type LPCWSTR = *const WCHAR;
 pub type LPWSTR = *mut WCHAR;
 
 pub type HANDLE = *mut LPVOID;
+pub type LPHANDLE = *mut HANDLE;
 
 pub const GENERIC_READ: DWORD = 0x80000000;
 pub const GENERIC_WRITE: DWORD = 0x40000000;
 pub const OPEN_EXISTING: DWORD = 3;
 pub const FILE_ATTRIBUTE_NORMAL: DWORD = 0x80;
 pub const INVALID_HANDLE_VALUE: HANDLE = !0 as HANDLE;
+pub const DUPLICATE_SAME_ACCESS: DWORD = 0x00000002;
 
 #[repr(C)]
 pub struct SECURITY_ATTRIBUTES {
@@ -154,6 +156,13 @@ extern "system" {
                        dwFlagsAndAttributes: DWORD,
                        hTemplmateFile: HANDLE) -> HANDLE;
     pub fn CloseHandle(hObject: HANDLE) -> BOOL;
+    pub fn DuplicateHandle(hResourceProcessHAndle: HANDLE,
+        				   hSourceHandle: HANDLE,
+        				   hTargetProcessHandle: HANDLE,
+        				   lpTargetHandle: LPHANDLE,
+        				   dwDesiredAccess: DWORD,
+        				   bInheritHandle: BOOL,
+        				   dwOptions: DWORD) -> BOOL;
     pub fn ReadFile(hFile: HANDLE,
                     lpBuffer: LPVOID,
                     nNumberOfBytesToRead: DWORD,
@@ -174,4 +183,5 @@ extern "system" {
     pub fn GetCommModemStatus(hFile: HANDLE, lpModemStat: *mut DWORD) -> BOOL;
 
     pub fn GetLastError() -> DWORD;
+    pub fn GetCurrentProcess() -> HANDLE;
 }


### PR DESCRIPTION
Fix of #21. 
