### PR TITLE
Allow users to inspect OS error code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,11 @@ impl StdError for Error {
 
 impl From<io::Error> for Error {
     fn from(io_error: io::Error) -> Error {
-        Error::new(0,ErrorKind::Io(io_error.kind()), format!("{}", io_error))
+        let err_no = match io_error.raw_os_error() {
+            Option::Some(x) => x,
+            Option::None => 0
+        };
+        Error::new(err_no,ErrorKind::Io(io_error.kind()), format!("{}", io_error))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,20 +59,30 @@ pub enum ErrorKind {
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
-    description: String
+    description: String,
+    code: i32
 }
 
 impl Error {
-    pub fn new<T: Into<String>>(kind: ErrorKind, description: T) -> Self {
+    pub fn new<T: Into<String>>(err_code: i32, kind: ErrorKind, description: T) -> Self {
         Error {
             kind: kind,
-            description: description.into()
+            description: description.into(),
+            code: err_code
         }
     }
 
     /// Returns the corresponding `ErrorKind` for this error.
     pub fn kind(&self) -> ErrorKind {
         self.kind
+    }
+
+    /// Attempts to return the OS-Native error code
+    pub fn raw_os_error(&self) -> Option<i32> {
+        match self.code {
+            0 => None,
+            _ => Some(self.code)
+        }
     }
 }
 
@@ -90,7 +100,7 @@ impl StdError for Error {
 
 impl From<io::Error> for Error {
     fn from(io_error: io::Error) -> Error {
-        Error::new(ErrorKind::Io(io_error.kind()), format!("{}", io_error))
+        Error::new(0,ErrorKind::Io(io_error.kind()), format!("{}", io_error))
     }
 }
 

--- a/src/posix/error.rs
+++ b/src/posix/error.rs
@@ -23,7 +23,7 @@ pub fn from_raw_os_error(errno: i32) -> ::Error {
         _ => ::ErrorKind::Io(io::ErrorKind::Other)
     };
 
-    ::Error::new(kind, error_string(errno))
+    ::Error::new(errno,kind, error_string(errno))
 }
 
 pub fn from_io_error(io_error: io::Error) -> ::Error {

--- a/src/windows/error.rs
+++ b/src/windows/error.rs
@@ -17,7 +17,7 @@ pub fn last_os_error() -> ::Error {
         _ => ::ErrorKind::Io(io::ErrorKind::Other)
     };
 
-    ::Error::new(kind, error_string(errno).trim())
+    ::Error::new(errno,kind, error_string(errno).trim())
 }
 
 // the rest of this module is borrowed from libstd


### PR DESCRIPTION
Currently you can't extract the OS error code from a serial error. This can be frustrating.

This change allows for programmers to call `raw_os_error(&self)->Option<i32>` which is part of [`io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html).

The goal is to allow programmers to see the fault of an error code which isn't covered by `Error::Kind` internally. 
