### PR TITLE
build: simplify dependencies using `cfg(unix)`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
       VENDOR: gnu
     - RUST_VERSION: stable
       VENDOR: msvc
-    - RUST_VERSION: 1.3.0
+    - RUST_VERSION: 1.8.0
       VENDOR: gnu
     - RUST_VERSION: beta
       VENDOR: gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: rust
+sudo: false
 os:
   - linux
   - osx
 rust:
-  - 1.3.0
+  - 1.8.0
   - stable
   - beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,58 +13,6 @@ keywords = ["serial", "hardware", "system", "RS232"]
 [dependencies]
 libc = "0.2.1"
 
-[target.aarch64-unknown-linux-gnu.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.arm-unknown-linux-gnueabi.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.arm-unknown-linux-gnueabihf.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.armv7-unknown-linux-gnueabihf.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.i686-apple-darwin.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.i686-unknown-linux-gnu.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.mips-unknown-linux-gnu.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.mipsel-unknown-linux-gnu.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.powerpc-unknown-linux-gnu.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.x86_64-apple-darwin.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.x86_64-unknown-dragonfly.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.x86_64-unknown-freebsd.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.x86_64-unknown-linux-gnu.dependencies]
-termios = "0.2.2"
-ioctl-rs = "0.1.5"
-
-[target.x86_64-unknown-openbsd.dependencies]
+[target.'cfg(unix)'.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"


### PR DESCRIPTION
Fixes #33.  Rather than trying to guess at all of the different
concrete target types that are unix, we can lean on rust a bit
more to tell us if our target is a unix platform.

This way, when new targets are added to the ecosystem they
should just work with this crate.

If windows support is added with different dependencies, they can
be added as simply as:

```
[target.'cfg(windows)'.dependencies]
```
