### PR TITLE
Custom baud rate

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -29,7 +29,7 @@ const BOTHER: c_uint = 0x1000;
 
 // FIXME: This constant should move to the termios crate
 #[cfg(target_os = "linux")]
-const TCSETS2: c_int = -2144578518;
+const TCSETS2: c_int = 0x402c542b;
 
 
 /// A TTY-based serial port implementation.

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -344,6 +344,15 @@ impl SerialPortSettings for TTYSettings {
             B3500000 => Some(::BaudOther(3500000)),
             #[cfg(target_os = "linux")]
             B4000000 => Some(::BaudOther(4000000)),
+            #[cfg(target_os = "linux")]
+            BOTHER => {
+
+                if self.termios.c_ospeed != self.termios.c_ispeed {
+                    return None;
+                }
+
+                Some(::BaudOther(self.termios.c_ospeed as usize))
+            }
 
             _ => None
         }
@@ -596,6 +605,14 @@ mod tests {
         settings.set_baud_rate(::Baud600).unwrap();
         settings.set_baud_rate(::Baud1200).unwrap();
         assert_eq!(settings.baud_rate(), Some(::Baud1200));
+    }
+
+    #[test]
+    fn tty_settings_sets_nonstandard_baud_rate() {
+        let mut settings = default_settings();
+
+        settings.set_baud_rate(::BaudOther(12345)).unwrap();
+        assert_eq!(settings.baud_rate(), Some(::BaudOther(12345)));
     }
 
     #[test]

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -414,7 +414,6 @@ impl SerialPortSettings for TTYSettings {
     }
 
     fn set_baud_rate(&mut self, baud_rate: ::BaudRate) -> ::Result<()> {
-        use self::libc::{EINVAL};
         use self::termios::cfsetspeed;
         use self::termios::{B50,B75,B110,B134,B150,B200,B300,B600,B1200,B1800,B2400,B4800,B9600,B19200,B38400};
         use self::termios::os::target::{B57600,B115200,B230400};
@@ -499,7 +498,11 @@ impl SerialPortSettings for TTYSettings {
                     return Ok(());
                 }
 
-                return Err(super::error::from_raw_os_error(EINVAL));
+                #[cfg(not(target_os = "linux"))]
+                {
+                    use self::libc::EINVAL;
+                    return Err(super::error::from_raw_os_error(EINVAL));
+                }
             }
         };
 


### PR DESCRIPTION
This pull request contains code that allows setting custom bit rates on Linux, which is very useful for handling strange or proprietary protocols.

For this to work, first https://github.com/dcuddeback/termios-rs/pull/8 needs to be reviewed and merged, then the dependency bumped (travis CI will fail until this is done, sorry).

Afterwards, a different ioctl will be used to set the speed. `TCSET2` respects custom baud rates.