### PR TITLE
Added support for building for x86_64-unknown-linux-musl triplet.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,7 @@ ioctl-rs = "0.1.5"
 [target.x86_64-unknown-openbsd.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
+
+[target.x86_64-unknown-linux-musl.dependencies]
+termios = "0.2.2"
+ioctl-rs = "0.1.5"


### PR DESCRIPTION
Added another specific build block to `Cargo.toml` enabling the correct build process with the x86_64-unknown-linux-musl triplet. Tested and working.