### PR TITLE
Add mips-unknown-linux-musl dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ ioctl-rs = "0.1.5"
 termios = "0.2.2"
 ioctl-rs = "0.1.5"
 
+[target.mips-unknown-linux-musl.dependencies]
+termios = "0.2.2"
+ioctl-rs = "0.1.5"
+
 [target.mipsel-unknown-linux-gnu.dependencies]
 termios = "0.2.2"
 ioctl-rs = "0.1.5"


### PR DESCRIPTION
This change adds the dependencies for the mips-unknown-linux-musl build target. 

Previously I was receiving the following error when attempting to build:
```
$ cargo build --release --target=mips-unknown-linux-musl
   Compiling serial v0.3.4
   Compiling regex v0.1.80
   Compiling cookie v0.2.5
error[E0463]: can't find crate for `termios`
 --> /Users/mojo/.cargo/registry/src/github.com-1ecc6299db9ec823/serial-0.3.4/src/posix/tty.rs:2:1
  |
2 | extern crate termios;
  | ^^^^^^^^^^^^^^^^^^^^^ can't find crate
error: aborting due to previous error
error: Could not compile `serial`.
Build failed, waiting for other jobs to finish...
error: build failed
```

Adding the dependencies to the Cargo.toml seems to fix it. Thanks!