### PR TITLE
Derive Clone, PartialEq and Eq for Error

### DIFF
--- a/serial-core/src/lib.rs
+++ b/serial-core/src/lib.rs
@@ -47,7 +47,7 @@ pub enum ErrorKind {
 }
 
 /// An error type for serial port operations.
-#[derive(Debug)]
+#[derive(Debug,Clone,PartialEq,Eq)]
 pub struct Error {
     kind: ErrorKind,
     description: String,


### PR DESCRIPTION
I'm not entirely sure if it makes sense to derive `ParialEq` and `Eq` since we would also compare the description string. One should probably just compare/match on the `ErrorKind` field.