### PR TITLE
Use `Option<Duration>` for timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 rust:
-  - 1.16.0
+  - 1.19.0
   - stable
   - beta
   - nightly

--- a/serial-core/README.md
+++ b/serial-core/README.md
@@ -52,7 +52,7 @@ fn probe<P: SerialPort>(port: &mut P) -> io::Result<()> {
     }));
 
     // I/O
-    try!(port.set_timeout(Duration::from_millis(100)));
+    try!(port.set_timeout(Some(Duration::from_millis(100))));
     try!(port.write(&buf[..]));
     try!(port.read(&mut buf[..]));
 
@@ -174,8 +174,8 @@ impl serial::SerialDevice for CustomSerialPort {
 
     fn read_settings(&self) -> serial::Result<Self::Settings> { ... }
     fn write_settings(&mut self, settings: &Self::Settings) -> serial::Result<()> { ... }
-    fn timeout(&self) -> Duration { ... }
-    fn set_timeout(&mut self, timeout: Duration) -> serial::Result<()> { ... }
+    fn timeout(&self) -> Option<Duration> { ... }
+    fn set_timeout(&mut self, timeout: Option<Duration>) -> serial::Result<()> { ... }
 
     fn set_rts(&mut self, level: bool) -> serial::Result<()> { ... }
     fn set_dtr(&mut self, level: bool) -> serial::Result<()> { ... }

--- a/serial-core/src/lib.rs
+++ b/serial-core/src/lib.rs
@@ -341,10 +341,10 @@ pub trait SerialDevice: io::Read + io::Write {
     fn write_settings(&mut self, settings: &Self::Settings) -> ::Result<()>;
 
     /// Returns the current timeout.
-    fn timeout(&self) -> Duration;
+    fn timeout(&self) -> Option<Duration>;
 
     /// Sets the timeout for future I/O operations.
-    fn set_timeout(&mut self, timeout: Duration) -> ::Result<()>;
+    fn set_timeout(&mut self, timeout: Option<Duration>) -> ::Result<()>;
 
     /// Sets the state of the RTS (Request To Send) control signal.
     ///
@@ -437,10 +437,10 @@ pub trait SerialDevice: io::Read + io::Write {
 /// The serial port will be closed when the value is dropped.
 pub trait SerialPort: io::Read + io::Write {
     /// Returns the current timeout.
-    fn timeout(&self) -> Duration;
+    fn timeout(&self) -> Option<Duration>;
 
     /// Sets the timeout for future I/O operations.
-    fn set_timeout(&mut self, timeout: Duration) -> ::Result<()>;
+    fn set_timeout(&mut self, timeout: Option<Duration>) -> ::Result<()>;
 
     /// Configures a serial port device.
     ///
@@ -576,11 +576,11 @@ pub trait SerialPort: io::Read + io::Write {
 impl<T> SerialPort for T
     where T: SerialDevice
 {
-    fn timeout(&self) -> Duration {
+    fn timeout(&self) -> Option<Duration> {
         T::timeout(self)
     }
 
-    fn set_timeout(&mut self, timeout: Duration) -> ::Result<()> {
+    fn set_timeout(&mut self, timeout: Option<Duration>) -> ::Result<()> {
         T::set_timeout(self, timeout)
     }
 

--- a/serial-unix/src/tty.rs
+++ b/serial-unix/src/tty.rs
@@ -30,7 +30,7 @@ const O_NOCTTY: c_int = 0;
 /// The port will be closed when the value is dropped.
 pub struct TTYPort {
     fd: RawFd,
-    timeout: Duration,
+    timeout: Option<Duration>,
 }
 
 impl TTYPort {
@@ -65,7 +65,7 @@ impl TTYPort {
 
         let mut port = TTYPort {
             fd: fd,
-            timeout: Duration::from_millis(100),
+            timeout: None,
         };
 
         // get exclusive access to device
@@ -205,11 +205,11 @@ impl SerialDevice for TTYPort {
         Ok(())
     }
 
-    fn timeout(&self) -> Duration {
+    fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
 
-    fn set_timeout(&mut self, timeout: Duration) -> core::Result<()> {
+    fn set_timeout(&mut self, timeout: Option<Duration>) -> core::Result<()> {
         self.timeout = timeout;
         Ok(())
     }

--- a/serial/README.md
+++ b/serial/README.md
@@ -59,7 +59,7 @@ fn interact<T: SerialPort>(port: &mut T) -> io::Result<()> {
         Ok(())
     }));
 
-    try!(port.set_timeout(Duration::from_millis(1000)));
+    try!(port.set_timeout(Some(Duration::from_millis(1000))));
 
     let mut buf: Vec<u8> = (0..255).collect();
 

--- a/serial/examples/probe_pins.rs
+++ b/serial/examples/probe_pins.rs
@@ -24,7 +24,7 @@ fn main() {
 
 fn probe_pins<T: SerialPort>(port: &mut T) -> serial::Result<()> {
     try!(port.configure(&SETTINGS));
-    try!(port.set_timeout(Duration::from_millis(100)));
+    try!(port.set_timeout(Some(Duration::from_millis(100))));
 
     try!(port.set_rts(false));
     try!(port.set_dtr(false));

--- a/serial/examples/read_write.rs
+++ b/serial/examples/read_write.rs
@@ -25,7 +25,7 @@ fn main() {
 
 fn interact<T: SerialPort>(port: &mut T) -> serial::Result<()> {
     try!(port.configure(&SETTINGS));
-    try!(port.set_timeout(Duration::from_secs(1)));
+    try!(port.set_timeout(Some(Duration::from_secs(1))));
 
     let mut buf: Vec<u8> = (0..255).collect();
 


### PR DESCRIPTION
A timeout of `None` means that operations will block indefinitely. This is similar to what [`std::net::TcpStream`](https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout) does.