### PR TITLE
implement io::{Read, Write} for &TTYPort

### DIFF
--- a/serial-unix/src/error.rs
+++ b/serial-unix/src/error.rs
@@ -5,22 +5,27 @@ use std::ffi::CStr;
 use std::io;
 use std::str;
 
-use libc::{c_int, c_char, size_t};
+use libc::{c_char, c_int, size_t};
 
 pub fn last_os_error() -> core::Error {
     from_raw_os_error(errno())
 }
 
 pub fn from_raw_os_error(errno: i32) -> core::Error {
-    use libc::{EBUSY, EISDIR, ELOOP, ENOTDIR, ENOENT, ENODEV, ENXIO, EACCES, EINVAL, ENAMETOOLONG, EINTR, EWOULDBLOCK};
+    use libc::{
+        EACCES, EBUSY, EINTR, EINVAL, EISDIR, ELOOP, ENAMETOOLONG, ENODEV, ENOENT, ENOTDIR, ENXIO,
+        EWOULDBLOCK,
+    };
 
     let kind = match errno {
-        EBUSY | EISDIR | ELOOP | ENOTDIR | ENOENT | ENODEV | ENXIO | EACCES => core::ErrorKind::NoDevice,
+        EBUSY | EISDIR | ELOOP | ENOTDIR | ENOENT | ENODEV | ENXIO | EACCES => {
+            core::ErrorKind::NoDevice
+        }
         EINVAL | ENAMETOOLONG => core::ErrorKind::InvalidInput,
 
-        EINTR       => core::ErrorKind::Io(io::ErrorKind::Interrupted),
+        EINTR => core::ErrorKind::Io(io::ErrorKind::Interrupted),
         EWOULDBLOCK => core::ErrorKind::Io(io::ErrorKind::WouldBlock),
-        _           => core::ErrorKind::Io(io::ErrorKind::Other),
+        _ => core::ErrorKind::Io(io::ErrorKind::Other),
     };
 
     core::Error::new(kind, error_string(errno))
@@ -44,51 +49,55 @@ const TMPBUF_SZ: usize = 128;
 pub fn errno() -> i32 {
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
     unsafe fn errno_location() -> *const c_int {
-        extern { fn __error() -> *const c_int; }
+        extern "C" {
+            fn __error() -> *const c_int;
+        }
         __error()
     }
 
     #[cfg(target_os = "bitrig")]
     fn errno_location() -> *const c_int {
-        extern {
+        extern "C" {
             fn __errno() -> *const c_int;
         }
-        unsafe {
-            __errno()
-        }
+        unsafe { __errno() }
     }
 
     #[cfg(target_os = "dragonfly")]
     unsafe fn errno_location() -> *const c_int {
-        extern { fn __dfly_error() -> *const c_int; }
+        extern "C" {
+            fn __dfly_error() -> *const c_int;
+        }
         __dfly_error()
     }
 
     #[cfg(target_os = "openbsd")]
     unsafe fn errno_location() -> *const c_int {
-        extern { fn __errno() -> *const c_int; }
+        extern "C" {
+            fn __errno() -> *const c_int;
+        }
         __errno()
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     unsafe fn errno_location() -> *const c_int {
-        extern { fn __errno_location() -> *const c_int; }
+        extern "C" {
+            fn __errno_location() -> *const c_int;
+        }
         __errno_location()
     }
 
-    unsafe {
-        (*errno_location()) as i32
-    }
+    unsafe { (*errno_location()) as i32 }
 }
 
 pub fn error_string(errno: i32) -> String {
     #[cfg(target_os = "linux")]
-    extern {
+    extern "C" {
         #[link_name = "__xpg_strerror_r"]
         fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: size_t) -> c_int;
     }
     #[cfg(not(target_os = "linux"))]
-    extern {
+    extern "C" {
         fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: size_t) -> c_int;
     }
 
@@ -101,6 +110,8 @@ pub fn error_string(errno: i32) -> String {
         }
 
         let p = p as *const _;
-        str::from_utf8(CStr::from_ptr(p).to_bytes()).unwrap().to_string()
+        str::from_utf8(CStr::from_ptr(p).to_bytes())
+            .unwrap()
+            .to_string()
     }
 }

--- a/serial-unix/src/lib.rs
+++ b/serial-unix/src/lib.rs
@@ -1,9 +1,9 @@
 //! Serial port implementation for Unix operating systems.
 
-extern crate serial_core as core;
-extern crate libc;
-extern crate termios;
 extern crate ioctl_rs as ioctl;
+extern crate libc;
+extern crate serial_core as core;
+extern crate termios;
 
 pub use tty::*;
 

--- a/serial-unix/src/tty.rs
+++ b/serial-unix/src/tty.rs
@@ -146,7 +146,7 @@ impl io::Read for TTYPort {
     }
 }
 
-impl io::Read for &TTYPort {
+impl<'a> io::Read for &'a TTYPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.read_impl(buf)
     }
@@ -162,7 +162,7 @@ impl io::Write for TTYPort {
     }
 }
 
-impl io::Write for &TTYPort {
+impl<'a> io::Write for &'a TTYPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.write_impl(buf)
     }

--- a/serial-unix/src/tty.rs
+++ b/serial-unix/src/tty.rs
@@ -1,7 +1,7 @@
 use core;
+use ioctl;
 use libc;
 use termios;
-use ioctl;
 
 use std::ffi::CString;
 use std::io;
@@ -14,7 +14,6 @@ use libc::{c_int, c_void, size_t};
 
 use core::{SerialDevice, SerialPortSettings};
 
-
 #[cfg(target_os = "linux")]
 const O_NOCTTY: c_int = 0x00000100;
 
@@ -23,7 +22,6 @@ const O_NOCTTY: c_int = 0x00020000;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 const O_NOCTTY: c_int = 0;
-
 
 /// A TTY-based serial port implementation.
 ///
@@ -51,7 +49,7 @@ impl TTYPort {
     /// * `InvalidInput` if `port` is not a valid device name.
     /// * `Io` for any other error while opening or initializing the device.
     pub fn open(path: &Path) -> core::Result<Self> {
-        use libc::{O_RDWR, O_NONBLOCK, F_SETFL, EINVAL};
+        use libc::{EINVAL, F_SETFL, O_NONBLOCK, O_RDWR};
 
         let cstr = match CString::new(path.as_os_str().as_bytes()) {
             Ok(s) => s,
@@ -88,8 +86,7 @@ impl TTYPort {
     fn set_pin(&mut self, pin: c_int, level: bool) -> core::Result<()> {
         let retval = if level {
             ioctl::tiocmbis(self.fd, pin)
-        }
-        else {
+        } else {
             ioctl::tiocmbic(self.fd, pin)
         };
 
@@ -128,14 +125,11 @@ impl io::Read for TTYPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         try!(super::poll::wait_read_fd(self.fd, self.timeout));
 
-        let len = unsafe {
-            libc::read(self.fd, buf.as_ptr() as *mut c_void, buf.len() as size_t)
-        };
+        let len = unsafe { libc::read(self.fd, buf.as_ptr() as *mut c_void, buf.len() as size_t) };
 
         if len >= 0 {
             Ok(len as usize)
-        }
-        else {
+        } else {
             Err(io::Error::last_os_error())
         }
     }
@@ -145,14 +139,11 @@ impl io::Write for TTYPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         try!(super::poll::wait_write_fd(self.fd, self.timeout));
 
-        let len = unsafe {
-            libc::write(self.fd, buf.as_ptr() as *mut c_void, buf.len() as size_t)
-        };
+        let len = unsafe { libc::write(self.fd, buf.as_ptr() as *mut c_void, buf.len() as size_t) };
 
         if len >= 0 {
             Ok(len as usize)
-        }
-        else {
+        } else {
             Err(io::Error::last_os_error())
         }
     }
@@ -166,10 +157,10 @@ impl SerialDevice for TTYPort {
     type Settings = TTYSettings;
 
     fn read_settings(&self) -> core::Result<TTYSettings> {
-        use termios::{CREAD, CLOCAL}; // cflags
-        use termios::{ICANON, ECHO, ECHOE, ECHOK, ECHONL, ISIG, IEXTEN}; // lflags
-        use termios::{OPOST}; // oflags
-        use termios::{INLCR, IGNCR, ICRNL, IGNBRK}; // iflags
+        use termios::OPOST; // oflags
+        use termios::{CLOCAL, CREAD}; // cflags
+        use termios::{ECHO, ECHOE, ECHOK, ECHONL, ICANON, IEXTEN, ISIG}; // lflags
+        use termios::{ICRNL, IGNBRK, IGNCR, INLCR}; // iflags
         use termios::{VMIN, VTIME}; // c_cc indexes
 
         let mut termios = match termios::Termios::from_fd(self.fd) {
@@ -190,8 +181,8 @@ impl SerialDevice for TTYPort {
     }
 
     fn write_settings(&mut self, settings: &TTYSettings) -> core::Result<()> {
-        use termios::{tcsetattr, tcflush};
-        use termios::{TCSANOW, TCIOFLUSH};
+        use termios::{tcflush, tcsetattr};
+        use termios::{TCIOFLUSH, TCSANOW};
 
         // write settings to TTY
         if let Err(err) = tcsetattr(self.fd, TCSANOW, &settings.termios) {
@@ -240,7 +231,7 @@ impl SerialDevice for TTYPort {
 }
 
 /// Serial port settings for TTY devices.
-#[derive(Debug,Copy,Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TTYSettings {
     termios: termios::Termios,
 }
@@ -253,21 +244,27 @@ impl TTYSettings {
 
 impl SerialPortSettings for TTYSettings {
     fn baud_rate(&self) -> Option<core::BaudRate> {
-        use termios::{cfgetospeed, cfgetispeed};
-        use termios::{B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200, B38400};
-        use termios::os::target::{B57600, B115200, B230400};
+        use termios::os::target::{B115200, B230400, B57600};
+        use termios::{cfgetispeed, cfgetospeed};
+        use termios::{
+            B110, B1200, B134, B150, B1800, B19200, B200, B2400, B300, B38400, B4800, B50, B600,
+            B75, B9600,
+        };
 
         #[cfg(target_os = "linux")]
-        use termios::os::linux::{B460800, B500000, B576000, B921600, B1000000, B1152000, B1500000, B2000000, B2500000, B3000000, B3500000, B4000000};
+        use termios::os::linux::{
+            B1000000, B1152000, B1500000, B2000000, B2500000, B3000000, B3500000, B4000000,
+            B460800, B500000, B576000, B921600,
+        };
 
         #[cfg(target_os = "macos")]
-        use termios::os::macos::{B7200, B14400, B28800, B76800};
+        use termios::os::macos::{B14400, B28800, B7200, B76800};
 
         #[cfg(target_os = "freebsd")]
-        use termios::os::freebsd::{B7200, B14400, B28800, B76800, B460800, B921600};
+        use termios::os::freebsd::{B14400, B28800, B460800, B7200, B76800, B921600};
 
         #[cfg(target_os = "openbsd")]
-        use termios::os::openbsd::{B7200, B14400, B28800, B76800};
+        use termios::os::openbsd::{B14400, B28800, B7200, B76800};
 
         let ospeed = cfgetospeed(&self.termios);
         let ispeed = cfgetispeed(&self.termios);
@@ -277,40 +274,40 @@ impl SerialPortSettings for TTYSettings {
         }
 
         match ospeed {
-            B50      => Some(core::BaudOther(50)),
-            B75      => Some(core::BaudOther(75)),
-            B110     => Some(core::Baud110),
-            B134     => Some(core::BaudOther(134)),
-            B150     => Some(core::BaudOther(150)),
-            B200     => Some(core::BaudOther(200)),
-            B300     => Some(core::Baud300),
-            B600     => Some(core::Baud600),
-            B1200    => Some(core::Baud1200),
-            B1800    => Some(core::BaudOther(1800)),
-            B2400    => Some(core::Baud2400),
-            B4800    => Some(core::Baud4800),
+            B50 => Some(core::BaudOther(50)),
+            B75 => Some(core::BaudOther(75)),
+            B110 => Some(core::Baud110),
+            B134 => Some(core::BaudOther(134)),
+            B150 => Some(core::BaudOther(150)),
+            B200 => Some(core::BaudOther(200)),
+            B300 => Some(core::Baud300),
+            B600 => Some(core::Baud600),
+            B1200 => Some(core::Baud1200),
+            B1800 => Some(core::BaudOther(1800)),
+            B2400 => Some(core::Baud2400),
+            B4800 => Some(core::Baud4800),
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            B7200    => Some(core::BaudOther(7200)),
-            B9600    => Some(core::Baud9600),
+            B7200 => Some(core::BaudOther(7200)),
+            B9600 => Some(core::Baud9600),
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            B14400   => Some(core::BaudOther(14400)),
-            B19200   => Some(core::Baud19200),
+            B14400 => Some(core::BaudOther(14400)),
+            B19200 => Some(core::Baud19200),
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            B28800   => Some(core::BaudOther(28800)),
-            B38400   => Some(core::Baud38400),
-            B57600   => Some(core::Baud57600),
+            B28800 => Some(core::BaudOther(28800)),
+            B38400 => Some(core::Baud38400),
+            B57600 => Some(core::Baud57600),
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            B76800   => Some(core::BaudOther(76800)),
-            B115200  => Some(core::Baud115200),
-            B230400  => Some(core::BaudOther(230400)),
+            B76800 => Some(core::BaudOther(76800)),
+            B115200 => Some(core::Baud115200),
+            B230400 => Some(core::BaudOther(230400)),
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-            B460800  => Some(core::BaudOther(460800)),
+            B460800 => Some(core::BaudOther(460800)),
             #[cfg(target_os = "linux")]
-            B500000  => Some(core::BaudOther(500000)),
+            B500000 => Some(core::BaudOther(500000)),
             #[cfg(target_os = "linux")]
-            B576000  => Some(core::BaudOther(576000)),
+            B576000 => Some(core::BaudOther(576000)),
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-            B921600  => Some(core::BaudOther(921600)),
+            B921600 => Some(core::BaudOther(921600)),
             #[cfg(target_os = "linux")]
             B1000000 => Some(core::BaudOther(1000000)),
             #[cfg(target_os = "linux")]
@@ -333,7 +330,7 @@ impl SerialPortSettings for TTYSettings {
     }
 
     fn char_size(&self) -> Option<core::CharSize> {
-        use termios::{CSIZE, CS5, CS6, CS7, CS8};
+        use termios::{CS5, CS6, CS7, CS8, CSIZE};
 
         match self.termios.c_cflag & CSIZE {
             CS8 => Some(core::Bits8),
@@ -351,12 +348,10 @@ impl SerialPortSettings for TTYSettings {
         if self.termios.c_cflag & PARENB != 0 {
             if self.termios.c_cflag & PARODD != 0 {
                 Some(core::ParityOdd)
-            }
-            else {
+            } else {
                 Some(core::ParityEven)
             }
-        }
-        else {
+        } else {
             Some(core::ParityNone)
         }
     }
@@ -366,23 +361,20 @@ impl SerialPortSettings for TTYSettings {
 
         if self.termios.c_cflag & CSTOPB != 0 {
             Some(core::Stop2)
-        }
-        else {
+        } else {
             Some(core::Stop1)
         }
     }
 
     fn flow_control(&self) -> Option<core::FlowControl> {
-        use termios::{IXON, IXOFF};
         use termios::os::target::CRTSCTS;
+        use termios::{IXOFF, IXON};
 
         if self.termios.c_cflag & CRTSCTS != 0 {
             Some(core::FlowHardware)
-        }
-        else if self.termios.c_iflag & (IXON | IXOFF) != 0 {
+        } else if self.termios.c_iflag & (IXON | IXOFF) != 0 {
             Some(core::FlowSoftware)
-        }
-        else {
+        } else {
             Some(core::FlowNone)
         }
     }
@@ -390,56 +382,62 @@ impl SerialPortSettings for TTYSettings {
     fn set_baud_rate(&mut self, baud_rate: core::BaudRate) -> core::Result<()> {
         use libc::EINVAL;
         use termios::cfsetspeed;
-        use termios::{B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200, B38400};
-        use termios::os::target::{B57600, B115200, B230400};
+        use termios::os::target::{B115200, B230400, B57600};
+        use termios::{
+            B110, B1200, B134, B150, B1800, B19200, B200, B2400, B300, B38400, B4800, B50, B600,
+            B75, B9600,
+        };
 
         #[cfg(target_os = "linux")]
-        use termios::os::linux::{B460800, B500000, B576000, B921600, B1000000, B1152000, B1500000, B2000000, B2500000, B3000000, B3500000, B4000000};
+        use termios::os::linux::{
+            B1000000, B1152000, B1500000, B2000000, B2500000, B3000000, B3500000, B4000000,
+            B460800, B500000, B576000, B921600,
+        };
 
         #[cfg(target_os = "macos")]
-        use termios::os::macos::{B7200, B14400, B28800, B76800};
+        use termios::os::macos::{B14400, B28800, B7200, B76800};
 
         #[cfg(target_os = "freebsd")]
-        use termios::os::freebsd::{B7200, B14400, B28800, B76800, B460800, B921600};
+        use termios::os::freebsd::{B14400, B28800, B460800, B7200, B76800, B921600};
 
         #[cfg(target_os = "openbsd")]
-        use termios::os::openbsd::{B7200, B14400, B28800, B76800};
+        use termios::os::openbsd::{B14400, B28800, B7200, B76800};
 
         let baud = match baud_rate {
-            core::BaudOther(50)      => B50,
-            core::BaudOther(75)      => B75,
-            core::Baud110            => B110,
-            core::BaudOther(134)     => B134,
-            core::BaudOther(150)     => B150,
-            core::BaudOther(200)     => B200,
-            core::Baud300            => B300,
-            core::Baud600            => B600,
-            core::Baud1200           => B1200,
-            core::BaudOther(1800)    => B1800,
-            core::Baud2400           => B2400,
-            core::Baud4800           => B4800,
+            core::BaudOther(50) => B50,
+            core::BaudOther(75) => B75,
+            core::Baud110 => B110,
+            core::BaudOther(134) => B134,
+            core::BaudOther(150) => B150,
+            core::BaudOther(200) => B200,
+            core::Baud300 => B300,
+            core::Baud600 => B600,
+            core::Baud1200 => B1200,
+            core::BaudOther(1800) => B1800,
+            core::Baud2400 => B2400,
+            core::Baud4800 => B4800,
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            core::BaudOther(7200)    => B7200,
-            core::Baud9600           => B9600,
+            core::BaudOther(7200) => B7200,
+            core::Baud9600 => B9600,
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            core::BaudOther(14400)   => B14400,
-            core::Baud19200          => B19200,
+            core::BaudOther(14400) => B14400,
+            core::Baud19200 => B19200,
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            core::BaudOther(28800)   => B28800,
-            core::Baud38400          => B38400,
-            core::Baud57600          => B57600,
+            core::BaudOther(28800) => B28800,
+            core::Baud38400 => B38400,
+            core::Baud57600 => B57600,
             #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-            core::BaudOther(76800)   => B76800,
-            core::Baud115200         => B115200,
-            core::BaudOther(230400)  => B230400,
+            core::BaudOther(76800) => B76800,
+            core::Baud115200 => B115200,
+            core::BaudOther(230400) => B230400,
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-            core::BaudOther(460800)  => B460800,
+            core::BaudOther(460800) => B460800,
             #[cfg(target_os = "linux")]
-            core::BaudOther(500000)  => B500000,
+            core::BaudOther(500000) => B500000,
             #[cfg(target_os = "linux")]
-            core::BaudOther(576000)  => B576000,
+            core::BaudOther(576000) => B576000,
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-            core::BaudOther(921600)  => B921600,
+            core::BaudOther(921600) => B921600,
             #[cfg(target_os = "linux")]
             core::BaudOther(1000000) => B1000000,
             #[cfg(target_os = "linux")]
@@ -467,7 +465,7 @@ impl SerialPortSettings for TTYSettings {
     }
 
     fn set_char_size(&mut self, char_size: core::CharSize) {
-        use termios::{CSIZE, CS5, CS6, CS7, CS8};
+        use termios::{CS5, CS6, CS7, CS8, CSIZE};
 
         let size = match char_size {
             core::Bits5 => CS5,
@@ -481,7 +479,7 @@ impl SerialPortSettings for TTYSettings {
     }
 
     fn set_parity(&mut self, parity: core::Parity) {
-        use termios::{PARENB, PARODD, INPCK, IGNPAR};
+        use termios::{IGNPAR, INPCK, PARENB, PARODD};
 
         match parity {
             core::ParityNone => {
@@ -513,8 +511,8 @@ impl SerialPortSettings for TTYSettings {
     }
 
     fn set_flow_control(&mut self, flow_control: core::FlowControl) {
-        use termios::{IXON, IXOFF};
         use termios::os::target::CRTSCTS;
+        use termios::{IXOFF, IXON};
 
         match flow_control {
             core::FlowNone => {
@@ -533,7 +531,6 @@ impl SerialPortSettings for TTYSettings {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use core;
@@ -544,7 +541,9 @@ mod tests {
     use core::prelude::*;
 
     fn default_settings() -> TTYSettings {
-        TTYSettings { termios: unsafe { mem::uninitialized() } }
+        TTYSettings {
+            termios: unsafe { mem::uninitialized() },
+        }
     }
 
     #[test]

--- a/serial-windows/src/com.rs
+++ b/serial-windows/src/com.rs
@@ -104,8 +104,8 @@ impl AsRawHandle for COMPort {
     }
 }
 
-impl io::Read for COMPort {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+impl COMPort {
+    fn read_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
         let mut len: DWORD = 0;
 
         match unsafe {
@@ -130,10 +130,8 @@ impl io::Read for COMPort {
             }
         }
     }
-}
 
-impl io::Write for COMPort {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write_impl(&self, buf: &[u8]) -> io::Result<usize> {
         let mut len: DWORD = 0;
 
         match unsafe {
@@ -150,11 +148,43 @@ impl io::Write for COMPort {
         }
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush_impl(&self) -> io::Result<()> {
         match unsafe { FlushFileBuffers(self.handle) } {
             0 => Err(io::Error::last_os_error()),
             _ => Ok(()),
         }
+    }
+}
+
+impl io::Read for COMPort {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read_impl()
+    }
+}
+
+impl io::Read for &COMPort {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read_impl()
+    }
+}
+
+impl io::Write for COMPort {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_impl()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_impl()
+    }
+}
+
+impl io::Write for &COMPort {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_impl()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_impl()
     }
 }
 

--- a/serial-windows/src/com.rs
+++ b/serial-windows/src/com.rs
@@ -11,8 +11,8 @@ use std::os::windows::prelude::*;
 
 use core::{SerialDevice, SerialPortSettings};
 
-use libc::c_void;
 use ffi::*;
+use libc::c_void;
 
 /// A serial port implementation for Windows COM ports.
 ///
@@ -47,7 +47,15 @@ impl COMPort {
         name.push(0);
 
         let handle = unsafe {
-            CreateFileW(name.as_ptr(), GENERIC_READ | GENERIC_WRITE, 0, ptr::null_mut(), OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0 as HANDLE)
+            CreateFileW(
+                name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                0,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                0 as HANDLE,
+            )
         };
 
         let timeout = Duration::from_millis(100);
@@ -60,8 +68,7 @@ impl COMPort {
 
             try!(port.set_timeout(timeout));
             Ok(port)
-        }
-        else {
+        } else {
             Err(error::last_os_error())
         }
     }
@@ -93,9 +100,7 @@ impl Drop for COMPort {
 
 impl AsRawHandle for COMPort {
     fn as_raw_handle(&self) -> RawHandle {
-        unsafe {
-            mem::transmute(self.handle)
-        }
+        unsafe { mem::transmute(self.handle) }
     }
 }
 
@@ -103,14 +108,24 @@ impl io::Read for COMPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut len: DWORD = 0;
 
-        match unsafe { ReadFile(self.handle, buf.as_mut_ptr() as *mut c_void, buf.len() as DWORD, &mut len, ptr::null_mut()) } {
+        match unsafe {
+            ReadFile(
+                self.handle,
+                buf.as_mut_ptr() as *mut c_void,
+                buf.len() as DWORD,
+                &mut len,
+                ptr::null_mut(),
+            )
+        } {
             0 => Err(io::Error::last_os_error()),
             _ => {
                 if len != 0 {
                     Ok(len as usize)
-                }
-                else {
-                    Err(io::Error::new(io::ErrorKind::TimedOut, "Operation timed out"))
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "Operation timed out",
+                    ))
                 }
             }
         }
@@ -121,7 +136,15 @@ impl io::Write for COMPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let mut len: DWORD = 0;
 
-        match unsafe { WriteFile(self.handle, buf.as_ptr() as *mut c_void, buf.len() as DWORD, &mut len, ptr::null_mut()) } {
+        match unsafe {
+            WriteFile(
+                self.handle,
+                buf.as_ptr() as *mut c_void,
+                buf.len() as DWORD,
+                &mut len,
+                ptr::null_mut(),
+            )
+        } {
             0 => Err(io::Error::last_os_error()),
             _ => Ok(len as usize),
         }
@@ -149,7 +172,6 @@ impl SerialDevice for COMPort {
 
                 Ok(COMSettings { inner: dcb })
             }
-
         }
     }
 
@@ -186,8 +208,7 @@ impl SerialDevice for COMPort {
     fn set_rts(&mut self, level: bool) -> core::Result<()> {
         if level {
             self.escape_comm_function(SETRTS)
-        }
-        else {
+        } else {
             self.escape_comm_function(CLRRTS)
         }
     }
@@ -195,8 +216,7 @@ impl SerialDevice for COMPort {
     fn set_dtr(&mut self, level: bool) -> core::Result<()> {
         if level {
             self.escape_comm_function(SETDTR)
-        }
-        else {
+        } else {
             self.escape_comm_function(CLRDTR)
         }
     }
@@ -218,9 +238,8 @@ impl SerialDevice for COMPort {
     }
 }
 
-
 /// Serial port settings for COM ports.
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct COMSettings {
     inner: DCB,
 }
@@ -228,22 +247,22 @@ pub struct COMSettings {
 impl SerialPortSettings for COMSettings {
     fn baud_rate(&self) -> Option<core::BaudRate> {
         match self.inner.BaudRate {
-            CBR_110    => Some(core::Baud110),
-            CBR_300    => Some(core::Baud300),
-            CBR_600    => Some(core::Baud600),
-            CBR_1200   => Some(core::Baud1200),
-            CBR_2400   => Some(core::Baud2400),
-            CBR_4800   => Some(core::Baud4800),
-            CBR_9600   => Some(core::Baud9600),
-            CBR_14400  => Some(core::BaudOther(14400)),
-            CBR_19200  => Some(core::Baud19200),
-            CBR_38400  => Some(core::Baud38400),
-            CBR_56000  => Some(core::BaudOther(56000)),
-            CBR_57600  => Some(core::Baud57600),
+            CBR_110 => Some(core::Baud110),
+            CBR_300 => Some(core::Baud300),
+            CBR_600 => Some(core::Baud600),
+            CBR_1200 => Some(core::Baud1200),
+            CBR_2400 => Some(core::Baud2400),
+            CBR_4800 => Some(core::Baud4800),
+            CBR_9600 => Some(core::Baud9600),
+            CBR_14400 => Some(core::BaudOther(14400)),
+            CBR_19200 => Some(core::Baud19200),
+            CBR_38400 => Some(core::Baud38400),
+            CBR_56000 => Some(core::BaudOther(56000)),
+            CBR_57600 => Some(core::Baud57600),
             CBR_115200 => Some(core::Baud115200),
             CBR_128000 => Some(core::BaudOther(128000)),
             CBR_256000 => Some(core::BaudOther(256000)),
-            n          => Some(core::BaudOther(n as usize)),
+            n => Some(core::BaudOther(n as usize)),
         }
     }
 
@@ -259,46 +278,44 @@ impl SerialPortSettings for COMSettings {
 
     fn parity(&self) -> Option<core::Parity> {
         match self.inner.Parity {
-            ODDPARITY  => Some(core::ParityOdd),
+            ODDPARITY => Some(core::ParityOdd),
             EVENPARITY => Some(core::ParityEven),
-            NOPARITY   => Some(core::ParityNone),
-            _          => None,
+            NOPARITY => Some(core::ParityNone),
+            _ => None,
         }
     }
 
     fn stop_bits(&self) -> Option<core::StopBits> {
         match self.inner.StopBits {
             TWOSTOPBITS => Some(core::Stop2),
-            ONESTOPBIT  => Some(core::Stop1),
-            _           => None,
+            ONESTOPBIT => Some(core::Stop1),
+            _ => None,
         }
     }
 
     fn flow_control(&self) -> Option<core::FlowControl> {
         if self.inner.fBits & (fOutxCtsFlow | fRtsControl) != 0 {
             Some(core::FlowHardware)
-        }
-        else if self.inner.fBits & (fOutX | fInX) != 0 {
+        } else if self.inner.fBits & (fOutX | fInX) != 0 {
             Some(core::FlowSoftware)
-        }
-        else {
+        } else {
             Some(core::FlowNone)
         }
     }
 
     fn set_baud_rate(&mut self, baud_rate: core::BaudRate) -> core::Result<()> {
         self.inner.BaudRate = match baud_rate {
-            core::Baud110      => CBR_110,
-            core::Baud300      => CBR_300,
-            core::Baud600      => CBR_600,
-            core::Baud1200     => CBR_1200,
-            core::Baud2400     => CBR_2400,
-            core::Baud4800     => CBR_4800,
-            core::Baud9600     => CBR_9600,
-            core::Baud19200    => CBR_19200,
-            core::Baud38400    => CBR_38400,
-            core::Baud57600    => CBR_57600,
-            core::Baud115200   => CBR_115200,
+            core::Baud110 => CBR_110,
+            core::Baud300 => CBR_300,
+            core::Baud600 => CBR_600,
+            core::Baud1200 => CBR_1200,
+            core::Baud2400 => CBR_2400,
+            core::Baud4800 => CBR_4800,
+            core::Baud9600 => CBR_9600,
+            core::Baud19200 => CBR_19200,
+            core::Baud38400 => CBR_38400,
+            core::Baud57600 => CBR_57600,
+            core::Baud115200 => CBR_115200,
             core::BaudOther(n) => n as DWORD,
         };
 
@@ -317,14 +334,13 @@ impl SerialPortSettings for COMSettings {
     fn set_parity(&mut self, parity: core::Parity) {
         self.inner.Parity = match parity {
             core::ParityNone => NOPARITY,
-            core::ParityOdd  => ODDPARITY,
+            core::ParityOdd => ODDPARITY,
             core::ParityEven => EVENPARITY,
         };
 
         if parity == core::ParityNone {
             self.inner.fBits &= !fParity;
-        }
-        else {
+        } else {
             self.inner.fBits |= fParity;
         }
     }

--- a/serial-windows/src/com.rs
+++ b/serial-windows/src/com.rs
@@ -162,15 +162,15 @@ impl io::Read for COMPort {
     }
 }
 
-impl io::Read for &COMPort {
+impl<'a> io::Read for &'a COMPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.read_impl()
+        self.read_impl(buf)
     }
 }
 
 impl io::Write for COMPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.write_impl()
+        self.write_impl(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -178,9 +178,9 @@ impl io::Write for COMPort {
     }
 }
 
-impl io::Write for &COMPort {
+impl<'a> io::Write for &'a COMPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.write_impl()
+        self.write_impl(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/serial-windows/src/error.rs
+++ b/serial-windows/src/error.rs
@@ -4,7 +4,7 @@ use ffi;
 use std::io;
 use std::ptr;
 
-use libc::{c_void, c_int};
+use libc::{c_int, c_void};
 
 const ERROR_FILE_NOT_FOUND: c_int = 2;
 const ERROR_PATH_NOT_FOUND: c_int = 3;
@@ -26,26 +26,25 @@ pub fn last_os_error() -> core::Error {
 // the rest of this module is borrowed from libstd
 
 fn errno() -> i32 {
-    unsafe {
-        ffi::GetLastError() as i32
-    }
+    unsafe { ffi::GetLastError() as i32 }
 }
 
 fn error_string(errnum: i32) -> String {
     #![allow(non_snake_case)]
 
-    use ffi::{DWORD, LPWSTR, LPVOID, WCHAR};
+    use ffi::{DWORD, LPVOID, LPWSTR, WCHAR};
 
     #[link_name = "kernel32"]
     extern "system" {
-        fn FormatMessageW(flags: DWORD,
-                          lpSrc: LPVOID,
-                          msgId: DWORD,
-                          langId: DWORD,
-                          buf: LPWSTR,
-                          nsize: DWORD,
-                          args: *const c_void)
-                          -> DWORD;
+        fn FormatMessageW(
+            flags: DWORD,
+            lpSrc: LPVOID,
+            msgId: DWORD,
+            langId: DWORD,
+            buf: LPWSTR,
+            nsize: DWORD,
+            args: *const c_void,
+        ) -> DWORD;
     }
 
     const FORMAT_MESSAGE_FROM_SYSTEM: DWORD = 0x00001000;
@@ -58,26 +57,32 @@ fn error_string(errnum: i32) -> String {
     let mut buf = [0 as WCHAR; 2048];
 
     unsafe {
-        let res = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                                 ptr::null_mut(),
-                                 errnum as DWORD,
-                                 langId,
-                                 buf.as_mut_ptr(),
-                                 buf.len() as DWORD,
-                                 ptr::null());
+        let res = FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            ptr::null_mut(),
+            errnum as DWORD,
+            langId,
+            buf.as_mut_ptr(),
+            buf.len() as DWORD,
+            ptr::null(),
+        );
         if res == 0 {
             // Sometimes FormatMessageW can fail e.g. system doesn't like langId,
             let fm_err = errno();
-            return format!("OS Error {} (FormatMessageW() returned error {})", errnum, fm_err);
+            return format!(
+                "OS Error {} (FormatMessageW() returned error {})",
+                errnum, fm_err
+            );
         }
 
         let b = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
         let msg = String::from_utf16(&buf[..b]);
         match msg {
             Ok(msg) => msg,
-            Err(..) => {
-                format!("OS Error {} (FormatMessageW() returned invalid UTF-16)", errnum)
-            }
+            Err(..) => format!(
+                "OS Error {} (FormatMessageW() returned invalid UTF-16)",
+                errnum
+            ),
         }
     }
 }

--- a/serial-windows/src/ffi.rs
+++ b/serial-windows/src/ffi.rs
@@ -1,8 +1,13 @@
-#![allow(non_snake_case,non_camel_case_types,non_upper_case_globals,dead_code)]
+#![allow(
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals,
+    dead_code
+)]
 
 use std::mem;
 
-use libc::{c_void, c_char, c_int, c_ulong, wchar_t};
+use libc::{c_char, c_int, c_ulong, c_void, wchar_t};
 
 pub type BYTE = u8;
 pub type WORD = u16;
@@ -44,7 +49,7 @@ pub struct OVERLAPPED {
 
 pub type LPOVERLAPPED = *mut OVERLAPPED;
 
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct DCB {
     pub DCBlength: DWORD,
@@ -65,49 +70,49 @@ pub struct DCB {
 }
 
 // BaudRate values
-pub const CBR_110:    DWORD = 110;
-pub const CBR_300:    DWORD = 300;
-pub const CBR_600:    DWORD = 600;
-pub const CBR_1200:   DWORD = 1200;
-pub const CBR_2400:   DWORD = 2400;
-pub const CBR_4800:   DWORD = 4800;
-pub const CBR_9600:   DWORD = 9600;
-pub const CBR_14400:  DWORD = 14400;
-pub const CBR_19200:  DWORD = 19200;
-pub const CBR_38400:  DWORD = 38400;
-pub const CBR_56000:  DWORD = 56000;
-pub const CBR_57600:  DWORD = 57600;
+pub const CBR_110: DWORD = 110;
+pub const CBR_300: DWORD = 300;
+pub const CBR_600: DWORD = 600;
+pub const CBR_1200: DWORD = 1200;
+pub const CBR_2400: DWORD = 2400;
+pub const CBR_4800: DWORD = 4800;
+pub const CBR_9600: DWORD = 9600;
+pub const CBR_14400: DWORD = 14400;
+pub const CBR_19200: DWORD = 19200;
+pub const CBR_38400: DWORD = 38400;
+pub const CBR_56000: DWORD = 56000;
+pub const CBR_57600: DWORD = 57600;
 pub const CBR_115200: DWORD = 115200;
 pub const CBR_128000: DWORD = 128000;
 pub const CBR_256000: DWORD = 256000;
 
 // fBits masks
-pub const fBinary:           DWORD = 0x00000001;
-pub const fParity:           DWORD = 0x00000002;
-pub const fOutxCtsFlow:      DWORD = 0x00000004;
-pub const fOutxDsrFlow:      DWORD = 0x00000008;
-pub const fDtrControl:       DWORD = 0x00000030;
-pub const fDsrSensitivity:   DWORD = 0x00000040;
+pub const fBinary: DWORD = 0x00000001;
+pub const fParity: DWORD = 0x00000002;
+pub const fOutxCtsFlow: DWORD = 0x00000004;
+pub const fOutxDsrFlow: DWORD = 0x00000008;
+pub const fDtrControl: DWORD = 0x00000030;
+pub const fDsrSensitivity: DWORD = 0x00000040;
 pub const fTXContinueOnXoff: DWORD = 0x00000080;
-pub const fOutX:             DWORD = 0x00000100;
-pub const fInX:              DWORD = 0x00000200;
-pub const fErrorChar:        DWORD = 0x00000400;
-pub const fNull:             DWORD = 0x00000800;
-pub const fRtsControl:       DWORD = 0x00003000;
-pub const fAbortOnError:     DWORD = 0x00004000;
-pub const fDummy2:           DWORD = 0xFFFF8000;
+pub const fOutX: DWORD = 0x00000100;
+pub const fInX: DWORD = 0x00000200;
+pub const fErrorChar: DWORD = 0x00000400;
+pub const fNull: DWORD = 0x00000800;
+pub const fRtsControl: DWORD = 0x00003000;
+pub const fAbortOnError: DWORD = 0x00004000;
+pub const fDummy2: DWORD = 0xFFFF8000;
 
 // Parity values
-pub const NOPARITY:    BYTE = 0;
-pub const ODDPARITY:   BYTE = 1;
-pub const EVENPARITY:  BYTE = 2;
-pub const MARKPARITY:  BYTE = 3;
+pub const NOPARITY: BYTE = 0;
+pub const ODDPARITY: BYTE = 1;
+pub const EVENPARITY: BYTE = 2;
+pub const MARKPARITY: BYTE = 3;
 pub const SPACEPARITY: BYTE = 4;
 
 // StopBits values
-pub const ONESTOPBIT:   BYTE = 0;
+pub const ONESTOPBIT: BYTE = 0;
 pub const ONE5STOPBITS: BYTE = 1;
-pub const TWOSTOPBITS:  BYTE = 2;
+pub const TWOSTOPBITS: BYTE = 2;
 
 impl DCB {
     pub fn new() -> Self {
@@ -118,22 +123,22 @@ impl DCB {
 }
 
 // EscapeCommFunction values
-pub const SETXOFF:  DWORD = 1;
-pub const SETXON:   DWORD = 2;
-pub const SETRTS:   DWORD = 3;
-pub const CLRRTS:   DWORD = 4;
-pub const SETDTR:   DWORD = 5;
-pub const CLRDTR:   DWORD = 6;
+pub const SETXOFF: DWORD = 1;
+pub const SETXON: DWORD = 2;
+pub const SETRTS: DWORD = 3;
+pub const CLRRTS: DWORD = 4;
+pub const SETDTR: DWORD = 5;
+pub const CLRDTR: DWORD = 6;
 pub const SETBREAK: DWORD = 8;
 pub const CLRBREAK: DWORD = 9;
 
 // Modem status masks
-pub const MS_CTS_ON:  DWORD = 0x0010;
-pub const MS_DSR_ON:  DWORD = 0x0020;
+pub const MS_CTS_ON: DWORD = 0x0010;
+pub const MS_DSR_ON: DWORD = 0x0020;
 pub const MS_RING_ON: DWORD = 0x0040;
 pub const MS_RLSD_ON: DWORD = 0x0080;
 
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct COMMTIMEOUTS {
     pub ReadIntervalTimeout: DWORD,
@@ -144,27 +149,30 @@ pub struct COMMTIMEOUTS {
 }
 
 extern "system" {
-    pub fn CreateFileW(lpFileName: LPCWSTR,
-                       dwDesiredAccess: DWORD,
-                       dwSharedMode: DWORD,
-                       lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
-                       dwCreationDisposition: DWORD,
-                       dwFlagsAndAttributes: DWORD,
-                       hTemplmateFile: HANDLE)
-                       -> HANDLE;
+    pub fn CreateFileW(
+        lpFileName: LPCWSTR,
+        dwDesiredAccess: DWORD,
+        dwSharedMode: DWORD,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+        dwCreationDisposition: DWORD,
+        dwFlagsAndAttributes: DWORD,
+        hTemplmateFile: HANDLE,
+    ) -> HANDLE;
     pub fn CloseHandle(hObject: HANDLE) -> BOOL;
-    pub fn ReadFile(hFile: HANDLE,
-                    lpBuffer: LPVOID,
-                    nNumberOfBytesToRead: DWORD,
-                    lpNumberOfBytesRead: LPDWORD,
-                    lpOverlapped: LPOVERLAPPED)
-                    -> BOOL;
-    pub fn WriteFile(hFile: HANDLE,
-                     lpBuffer: LPVOID,
-                     nNumberOfBytesToWrite: DWORD,
-                     lpNumberOfBytesWritten: LPDWORD,
-                     lpOverlapped: LPOVERLAPPED)
-                     -> BOOL;
+    pub fn ReadFile(
+        hFile: HANDLE,
+        lpBuffer: LPVOID,
+        nNumberOfBytesToRead: DWORD,
+        lpNumberOfBytesRead: LPDWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn WriteFile(
+        hFile: HANDLE,
+        lpBuffer: LPVOID,
+        nNumberOfBytesToWrite: DWORD,
+        lpNumberOfBytesWritten: LPDWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
     pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;
 
     pub fn GetCommState(hFile: HANDLE, lpDCB: *mut DCB) -> BOOL;

--- a/serial-windows/src/lib.rs
+++ b/serial-windows/src/lib.rs
@@ -1,7 +1,7 @@
 //! Serial port implementation for Windows.
 
-extern crate serial_core as core;
 extern crate libc;
+extern crate serial_core as core;
 
 pub use self::com::*;
 


### PR DESCRIPTION
- This pull request apply rustfmt for serial-unix.
- Add io::Read and io::Write for &TTYPort

I am not sure this is safe. But std::io::File implement both. I think operations over os-system are system defined and  rust compiler can't guarantee anything about that.

Without this PR we can't use `std::io::copy()` without `unsafe`. 