### PR TITLE
Add a purge() method

### DIFF
--- a/serial-windows/src/com.rs
+++ b/serial-windows/src/com.rs
@@ -183,6 +183,21 @@ impl SerialDevice for COMPort {
         Ok(())
     }
 
+    fn purge(&mut self, queue: core::Queue) -> core::Result<()> {
+        use core::Queue::*;
+
+        let flags = match queue {
+            Input => PURGE_RXCLEAR,
+            Output => PURGE_TXCLEAR,
+            Both => PURGE_RXCLEAR | PURGE_TXCLEAR,
+        };
+
+        match unsafe { PurgeComm(self.handle, flags) } {
+            0 => Err(error::last_os_error()),
+            _ => Ok(()),
+        }
+    }
+
     fn set_rts(&mut self, level: bool) -> core::Result<()> {
         if level {
             self.escape_comm_function(SETRTS)

--- a/serial-windows/src/ffi.rs
+++ b/serial-windows/src/ffi.rs
@@ -133,6 +133,10 @@ pub const MS_DSR_ON:  DWORD = 0x0020;
 pub const MS_RING_ON: DWORD = 0x0040;
 pub const MS_RLSD_ON: DWORD = 0x0080;
 
+// PurgeComm values
+pub const PURGE_RXCLEAR: DWORD = 0x0008;
+pub const PURGE_TXCLEAR: DWORD = 0x0004;
+
 #[derive(Copy,Clone,Debug)]
 #[repr(C)]
 pub struct COMMTIMEOUTS {
@@ -166,6 +170,7 @@ extern "system" {
                      lpOverlapped: LPOVERLAPPED)
                      -> BOOL;
     pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;
+    pub fn PurgeComm(hFile: HANDLE, dwFlags: DWORD) -> BOOL;
 
     pub fn GetCommState(hFile: HANDLE, lpDCB: *mut DCB) -> BOOL;
     pub fn SetCommState(hFile: HANDLE, lpDCB: *const DCB) -> BOOL;


### PR DESCRIPTION
Both Windows and Unix have functions (`PurgeComm` and `tcflush`) that clear out the underlying send and receive buffers without sending the data. This can be useful for call-and-response serial connections, where it makes sense to discard any existing data as invalid. There is a user demand for this addition (#56). This PR proposes a purge API and provides a Windows implementation.

Both `PurgeComm` and `tcflush` are single functions that accept a parameter indicating whether the input/receive queue, the output/send queue, or both queues should be flushed. This mimics that arrangement, adding a `purge(&self, queue: Queue)` to `SerialPort` and `SerialDevice`. The `Queue` enum allows for input, output, or both.

On Windows, `purge` is implemented using a single call to `PurgeComm`. The Unix implementation should be similar, but I don't have a machine nearby to test with, so this is submitted as a draft PR for now with no Unix implementation.