### PR TITLE
set COMMTIMEOUTS for POSIX-like read timeout behavior on Windows

### DIFF
--- a/serial-windows/src/com.rs
+++ b/serial-windows/src/com.rs
@@ -167,10 +167,19 @@ impl SerialDevice for COMPort {
     fn set_timeout(&mut self, timeout: Duration) -> core::Result<()> {
         let milliseconds = timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000;
 
+        // populate COMMTIMEOUTS struct
+        // https://docs.microsoft.com/en-us/windows/win32/devio/time-outs
+        // https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts
         let timeouts = COMMTIMEOUTS {
-            ReadIntervalTimeout: 0,
-            ReadTotalTimeoutMultiplier: 0,
+            // return as soon as bytes become available (like POSIX would) and
+            // block up to given duration otherwise
+            // https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts#remarks
+            ReadIntervalTimeout: MAXDWORD,
+            ReadTotalTimeoutMultiplier: MAXDWORD,
             ReadTotalTimeoutConstant: milliseconds as DWORD,
+            // block without timeout until write is complete
+            // MAXDWORD is *not* a reserved WriteTotalTimeoutMultiplier
+            // value, i.e., setting it incurs a long write timeout
             WriteTotalTimeoutMultiplier: 0,
             WriteTotalTimeoutConstant: 0,
         };

--- a/serial-windows/src/ffi.rs
+++ b/serial-windows/src/ffi.rs
@@ -18,6 +18,8 @@ pub type LPWSTR = *mut WCHAR;
 
 pub type HANDLE = *mut LPVOID;
 
+pub const MAXDWORD: DWORD = 0xFFFFFFFF;
+
 pub const GENERIC_READ: DWORD = 0x80000000;
 pub const GENERIC_WRITE: DWORD = 0x40000000;
 pub const OPEN_EXISTING: DWORD = 3;


### PR DESCRIPTION
The current read timeout behavior implemented by `serial-windows` differs significantly from the read timeouts of `serial-unix`. On Windows, read calls do not return immediately when bytes are/become available, but instead wait for the timeout to expire. In contrast, on Linux (tested, but should be true for all POSIX systems) read calls return as soon as bytes are available. Particularly for interactive implementations, the Windows behavior is suboptimal.

This pull request implements the POSIX-behavior on Windows by setting up `COMMTIMEOUTS` accordingly ([see Windows API documentation](https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts#remarks)).