### PR TITLE
fix warnings

### DIFF
--- a/serial-core/README.md
+++ b/serial-core/README.md
@@ -42,23 +42,23 @@ fn probe<P: SerialPort>(port: &mut P) -> io::Result<()> {
     let mut buf: Vec<u8> = (0..255).collect();
 
     // configuration
-    try!(port.reconfigure(&|settings| {
-        try!(settings.set_baud_rate(serial::Baud9600));
+    port.reconfigure(&|settings| {
+        settings.set_baud_rate(serial::Baud9600)?;
         settings.set_char_size(serial::Bits8);
         settings.set_parity(serial::ParityNone);
         settings.set_stop_bits(serial::Stop1);
         settings.set_flow_control(serial::FlowNone);
         Ok(())
-    }));
+    })?;
 
     // I/O
-    try!(port.set_timeout(Duration::from_millis(100)));
-    try!(port.write(&buf[..]));
-    try!(port.read(&mut buf[..]));
+    port.set_timeout(Duration::from_millis(99))?;
+    port.write(&buf[..])?;
+    port.read(&mut buf[..])?;
 
     // control signals
-    try!(port.set_dtr(true));
-    try!(port.read_dsr());
+    port.set_dtr(true)?;
+    port.read_dsr()?;
 
     Ok(())
 }
@@ -91,20 +91,20 @@ impl<P: SerialPort> Greet for Handle<P> {
     fn get_name(&mut self) -> serial::Result<String> {
         let mut name = String::new();
 
-        try!(self.port.write("What is your name? "));
-        try!(self.port.read_to_string(&mut name));
+        self.port.write("What is your name? ")?;
+        self.port.read_to_string(&mut name)?;
 
         Ok(name)
     }
 
     fn say_hello(&mut self, name: &String) -> serial::Result<()> {
-        try!(writeln!(&mut self.port, "Hello, {}!", name));
+        writeln!(&mut self.port, "Hello, {}!", name)?;
         Ok(())
     }
 }
 
 fn greet(greeter: &mut Greet) -> serial::Result<()> {
-    let name = try!(greeter.get_name());
+    let name = greeter.get_name()?;
 
     greeter.say_hello(name)
 }

--- a/serial-unix/src/error.rs
+++ b/serial-unix/src/error.rs
@@ -1,6 +1,5 @@
 use core;
 
-use std::error::Error;
 use std::ffi::CStr;
 use std::io;
 use std::str;
@@ -30,7 +29,7 @@ pub fn from_io_error(io_error: io::Error) -> core::Error {
     match io_error.raw_os_error() {
         Some(errno) => from_raw_os_error(errno),
         None => {
-            let description = io_error.description().to_string();
+            let description = io_error.to_string();
 
             core::Error::new(core::ErrorKind::Io(io_error.kind()), description)
         }

--- a/serial-unix/src/tty.rs
+++ b/serial-unix/src/tty.rs
@@ -79,8 +79,8 @@ impl TTYPort {
         }
 
         // apply initial settings
-        let settings = try!(port.read_settings());
-        try!(port.write_settings(&settings));
+        let settings = port.read_settings()?;
+        port.write_settings(&settings)?;
 
         Ok(port)
     }
@@ -126,7 +126,7 @@ impl AsRawFd for TTYPort {
 
 impl io::Read for TTYPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        try!(super::poll::wait_read_fd(self.fd, self.timeout));
+        super::poll::wait_read_fd(self.fd, self.timeout)?;
 
         let len = unsafe {
             libc::read(self.fd, buf.as_ptr() as *mut c_void, buf.len() as size_t)
@@ -143,7 +143,7 @@ impl io::Read for TTYPort {
 
 impl io::Write for TTYPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        try!(super::poll::wait_write_fd(self.fd, self.timeout));
+        super::poll::wait_write_fd(self.fd, self.timeout)?;
 
         let len = unsafe {
             libc::write(self.fd, buf.as_ptr() as *mut c_void, buf.len() as size_t)

--- a/serial-windows/src/com.rs
+++ b/serial-windows/src/com.rs
@@ -58,7 +58,7 @@ impl COMPort {
                 timeout: timeout,
             };
 
-            try!(port.set_timeout(timeout));
+            port.set_timeout(timeout)?;
             Ok(port)
         }
         else {

--- a/serial/README.md
+++ b/serial/README.md
@@ -50,21 +50,21 @@ fn main() {
 }
 
 fn interact<T: SerialPort>(port: &mut T) -> io::Result<()> {
-    try!(port.reconfigure(&|settings| {
-        try!(settings.set_baud_rate(serial::Baud9600));
+    port.reconfigure(&|settings| {
+        settings.set_baud_rate(serial::Baud9600)?;
         settings.set_char_size(serial::Bits8);
         settings.set_parity(serial::ParityNone);
         settings.set_stop_bits(serial::Stop1);
         settings.set_flow_control(serial::FlowNone);
         Ok(())
-    }));
+    })?;
 
-    try!(port.set_timeout(Duration::from_millis(1000)));
+    port.set_timeout(Duration::from_millis(1000))?;
 
     let mut buf: Vec<u8> = (0..255).collect();
 
-    try!(port.write(&buf[..]));
-    try!(port.read(&mut buf[..]));
+    port.write(&buf[..])?;
+    port.read(&mut buf[..])?;
 
     Ok(())
 }

--- a/serial/examples/probe_pins.rs
+++ b/serial/examples/probe_pins.rs
@@ -23,11 +23,11 @@ fn main() {
 }
 
 fn probe_pins<T: SerialPort>(port: &mut T) -> serial::Result<()> {
-    try!(port.configure(&SETTINGS));
-    try!(port.set_timeout(Duration::from_millis(100)));
+    port.configure(&SETTINGS)?;
+    port.set_timeout(Duration::from_millis(100))?;
 
-    try!(port.set_rts(false));
-    try!(port.set_dtr(false));
+    port.set_rts(false)?;
+    port.set_dtr(false)?;
 
     let mut rts = false;
     let mut dtr = false;
@@ -38,20 +38,20 @@ fn probe_pins<T: SerialPort>(port: &mut T) -> serial::Result<()> {
 
         if toggle {
             rts = !rts;
-            try!(port.set_rts(rts));
+            port.set_rts(rts)?;
         }
         else {
             dtr = !dtr;
-            try!(port.set_dtr(dtr));
+            port.set_dtr(dtr)?;
         }
 
         println!("RTS={:5?} DTR={:5?} CTS={:5?} DSR={:5?} RI={:5?} CD={:?}",
                  rts,
                  dtr,
-                 try!(port.read_cts()),
-                 try!(port.read_dsr()),
-                 try!(port.read_ri()),
-                 try!(port.read_cd()));
+                 port.read_cts()?,
+                 port.read_dsr()?,
+                 port.read_ri()?,
+                 port.read_cd()?);
 
         toggle = !toggle;
     }

--- a/serial/examples/read_write.rs
+++ b/serial/examples/read_write.rs
@@ -3,7 +3,6 @@ extern crate serial;
 use std::env;
 use std::time::Duration;
 
-use std::io::prelude::*;
 use serial::prelude::*;
 
 const SETTINGS: serial::PortSettings = serial::PortSettings {
@@ -24,16 +23,16 @@ fn main() {
 }
 
 fn interact<T: SerialPort>(port: &mut T) -> serial::Result<()> {
-    try!(port.configure(&SETTINGS));
-    try!(port.set_timeout(Duration::from_secs(1)));
+    port.configure(&SETTINGS)?;
+    port.set_timeout(Duration::from_secs(1))?;
 
     let mut buf: Vec<u8> = (0..255).collect();
 
     println!("writing bytes");
-    try!(port.write(&buf[..]));
+    port.write(&buf[..])?;
 
     println!("reading bytes");
-    try!(port.read(&mut buf[..]));
+    port.read(&mut buf[..])?;
 
     Ok(())
 }


### PR DESCRIPTION
This fixes a lot of warnings that occur in the latest edition, we should probably set the edition in the `Cargo.toml` s for the future (should I add that in this PR?)